### PR TITLE
perf(db): Evita leitura redundante após inserção no upsert

### DIFF
--- a/crates/xpm-core/src/db/operations.rs
+++ b/crates/xpm-core/src/db/operations.rs
@@ -168,11 +168,10 @@ impl Database {
         } else {
             rw.insert(package.clone())?;
             rw.commit()?;
-            // Get the inserted package with ID
-            let r = self.db.r_transaction()?;
-            let inserted: Option<Package> =
-                r.get().secondary(PackageKey::name, package.name.clone())?;
-            Ok(inserted.unwrap_or(package))
+            // Return the package directly to avoid an extra read transaction.
+            // This is safe because package IDs are deterministically generated (SHA256)
+            // before insertion, and native_db does not alter primary keys.
+            Ok(package)
         }
     }
 
@@ -228,9 +227,10 @@ impl Database {
         } else {
             rw.insert(repo.clone())?;
             rw.commit()?;
-            let r = self.db.r_transaction()?;
-            let inserted: Option<Repo> = r.get().secondary(RepoKey::url, repo.url.clone())?;
-            Ok(inserted.unwrap_or(repo))
+            // Return the repo directly to avoid an extra read transaction.
+            // This is safe because repo IDs are deterministically generated (SHA256)
+            // before insertion, and native_db does not alter primary keys.
+            Ok(repo)
         }
     }
 


### PR DESCRIPTION
Este PR remove a releitura redundante após a inserção de um pacote ou repositório no banco de dados (`native_db`), otimizando o desempenho das operações de `upsert`.

Essa otimização é perfeitamente segura porque o sistema de persistência do `xpm-core` foi projetado para utilizar IDs determinísticos (os primeiros 8 bytes de um hash SHA256 da chave única), que já estão presentes no objeto em memória durante a chamada do `upsert`. Como o `native_db` não emprega triggers ou sequências auto-incrementais que modificam a tupla do lado do banco, o retorno direto da instância recém-inserida (`package` ou `repo`) mantém a consistência total do ciclo de vida dos dados e evita uma nova transação de leitura.

Foi adicionado um comentário no código em cada ponto de modificação explicitando o porquê essa operação é segura e intencional. As validações via testes atestam que não há regressões funcionais. Nenhuma dependência foi alterada e a integridade da arquitetura foi estritamente preservada.

---
*PR created automatically by Jules for task [2546461091206562224](https://jules.google.com/task/2546461091206562224) started by @insign*