### PR TITLE
perf: increase file reading buffer for checksum operations

### DIFF
--- a/crates/xpm-cli/src/commands/search.rs
+++ b/crates/xpm-cli/src/commands/search.rs
@@ -126,7 +126,7 @@ pub async fn run(
     let mut aur: Vec<_> = native_packages.iter().filter(|p| p.is_aur()).collect();
 
     // Sort AUR by votes ascending (most voted at bottom, near prompt)
-    aur.sort_by(|a, b| a.popularity.cmp(&b.popularity));
+    aur.sort_by_key(|a| a.popularity);
 
     // Invert official if not pre-sorted
     if !pm_pre_sorted && !official.is_empty() {

--- a/crates/xpm-core/src/utils/checksum.rs
+++ b/crates/xpm-core/src/utils/checksum.rs
@@ -56,8 +56,7 @@ pub struct Checksum;
 impl Checksum {
     /// Calculate checksum of a file
     pub fn calculate(path: &Path, algorithm: ChecksumAlgorithm) -> Result<String> {
-        let mut file =
-            File::open(path).with_context(|| format!("Failed to open file: {}", path.display()))?;
+        let mut file = File::open(path).with_context(|| format!("Failed to open file: {}", path.display()))?;
 
         match algorithm {
             ChecksumAlgorithm::Md5 => Self::compute_digest::<md5::Md5>(&mut file),

--- a/crates/xpm-core/src/utils/checksum.rs
+++ b/crates/xpm-core/src/utils/checksum.rs
@@ -56,7 +56,8 @@ pub struct Checksum;
 impl Checksum {
     /// Calculate checksum of a file
     pub fn calculate(path: &Path, algorithm: ChecksumAlgorithm) -> Result<String> {
-        let mut file = File::open(path).with_context(|| format!("Failed to open file: {}", path.display()))?;
+        let mut file =
+            File::open(path).with_context(|| format!("Failed to open file: {}", path.display()))?;
 
         match algorithm {
             ChecksumAlgorithm::Md5 => Self::compute_digest::<md5::Md5>(&mut file),

--- a/crates/xpm-core/src/utils/checksum.rs
+++ b/crates/xpm-core/src/utils/checksum.rs
@@ -74,7 +74,8 @@ impl Checksum {
     /// Compute digest from a reader
     fn compute_digest<D: Digest>(reader: &mut impl Read) -> Result<String> {
         let mut hasher = D::new();
-        let mut buffer = [0; 8192];
+        // Use a 128KB buffer for better read performance with large files
+        let mut buffer = vec![0; 128 * 1024];
         loop {
             let count = reader.read(&mut buffer).context("Failed to read file")?;
             if count == 0 {
@@ -272,8 +273,8 @@ mod tests {
     #[test]
     fn test_large_file_checksum() -> Result<()> {
         let mut file = NamedTempFile::new()?;
-        // Write 20KB of data (larger than 8KB buffer)
-        let data = vec![b'a'; 1024 * 20];
+        // Write 200KB of data (larger than 128KB buffer)
+        let data = vec![b'a'; 1024 * 200];
         file.write_all(&data)?;
 
         let hash = Checksum::calculate(file.path(), ChecksumAlgorithm::Sha256)?;


### PR DESCRIPTION
This PR delivers a single concrete performance improvement.

It increases the chunk reading buffer in `Checksum::calculate` from a small 8KB stack-allocated array to a larger 128KB heap-allocated vector. For a package manager that routinely downloads and hashes large package files, limiting the amount of I/O system calls improves checksum verification throughput. The heap allocation correctly avoids potential stack overflows that could occur with a 128KB array. The test suite has been proportionally updated to exercise the loop with the new buffer size.

---
*PR created automatically by Jules for task [7087809923071589715](https://jules.google.com/task/7087809923071589715) started by @insign*