### PR TITLE
fix: Apply limit after sorting package search results

### DIFF
--- a/crates/xpm-cli/src/commands/search.rs
+++ b/crates/xpm-cli/src/commands/search.rs
@@ -126,7 +126,7 @@ pub async fn run(
     let mut aur: Vec<_> = native_packages.iter().filter(|p| p.is_aur()).collect();
 
     // Sort AUR by votes ascending (most voted at bottom, near prompt)
-    aur.sort_by(|a, b| a.popularity.cmp(&b.popularity));
+    aur.sort_by_key(|a| a.popularity);
 
     // Invert official if not pre-sorted
     if !pm_pre_sorted && !official.is_empty() {

--- a/crates/xpm-core/src/db/operations.rs
+++ b/crates/xpm-core/src/db/operations.rs
@@ -129,11 +129,14 @@ impl Database {
                             .unwrap_or(false)
                 })
             })
-            .take(limit)
             .collect();
 
         // Sort by name
         results.sort_by(|a, b| a.name.cmp(&b.name));
+
+        // Apply limit after sorting
+        results.truncate(limit);
+
         Ok(results)
     }
 
@@ -447,6 +450,21 @@ mod tests {
         assert_eq!(results.len(), 2); // neovim and emacs
         assert!(results.iter().any(|p| p.name == "neovim"));
         assert!(results.iter().any(|p| p.name == "emacs"));
+
+        // Add a fourth package to test sorting before limit
+        let p4 = Package {
+            name: "avim".to_string(),
+            desc: Some("Another vim text editor".to_string()),
+            ..Package::new("avim")
+        };
+        db.upsert_package(p4)?;
+
+        // Search for "text editor" with limit 2
+        // Should return "avim" and "emacs" (alphabetically first 2 out of 3)
+        let results = db.search_packages(&["text".to_string(), "editor".to_string()], 2)?;
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].name, "avim");
+        assert_eq!(results[1].name, "emacs");
 
         Ok(())
     }


### PR DESCRIPTION
This PR fixes a bug in `xpm-core`'s package search where result limits were applied before sorting by name.

Because `take(limit)` was called on the `filter` iterator prior to `.collect()` and `.sort_by`, the search would grab up to N items based on the database's internal iteration order and only sort those N items. This meant that alphabetically first items might randomly be excluded if the total match count exceeded the limit.

This patch fixes the issue by collecting all matches, sorting them alphabetically, and *then* applying `truncate(limit)`. A new unit test is also added to ensure this logic correctly returns the first alphabetical items when a limit smaller than the matching set size is requested.

---
*PR created automatically by Jules for task [2192754536153550055](https://jules.google.com/task/2192754536153550055) started by @insign*