### PR TITLE
fix: Improve search precision using AND logic for multi-term queries

### DIFF
--- a/crates/xpm-core/src/db/operations.rs
+++ b/crates/xpm-core/src/db/operations.rs
@@ -115,7 +115,7 @@ impl Database {
             .all()?
             .filter_map(|p| p.ok())
             .filter(|pkg: &Package| {
-                terms_lower.iter().any(|term| {
+                terms_lower.iter().all(|term| {
                     pkg.name.to_lowercase().contains(term)
                         || pkg
                             .desc
@@ -465,6 +465,29 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].name, "avim");
         assert_eq!(results[1].name, "emacs");
+
+        // Test AND logic for multi-term search
+        let p5 = Package {
+            name: "testpkg".to_string(),
+            desc: Some("This is a text processing tool".to_string()),
+            ..Package::new("testpkg")
+        };
+        db.upsert_package(p5)?;
+
+        let p6 = Package {
+            name: "editorpkg".to_string(),
+            desc: Some("This is an image editor".to_string()),
+            ..Package::new("editorpkg")
+        };
+        db.upsert_package(p6)?;
+
+        // Search for "text editor" should NOT return testpkg or editorpkg because they don't match BOTH terms
+        // It should only return neovim, emacs, and avim (which match both "text" and "editor")
+        let results = db.search_packages(&["text".to_string(), "editor".to_string()], 10)?;
+        assert_eq!(results.len(), 3);
+        assert!(results.iter().any(|p| p.name == "neovim"));
+        assert!(results.iter().any(|p| p.name == "emacs"));
+        assert!(results.iter().any(|p| p.name == "avim"));
 
         Ok(())
     }

--- a/crates/xpm-core/src/db/operations.rs
+++ b/crates/xpm-core/src/db/operations.rs
@@ -104,10 +104,14 @@ impl Database {
         Ok(pkg)
     }
 
-    /// Search packages by term (searches name, desc, title)
+    /// Search packages matching every term in name, description, or title.
     pub fn search_packages(&self, terms: &[String], limit: usize) -> Result<Vec<Package>> {
-        let r = self.db.r_transaction()?;
         let terms_lower: Vec<String> = terms.iter().map(|t| t.to_lowercase()).collect();
+        if terms_lower.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let r = self.db.r_transaction()?;
 
         let mut results: Vec<Package> = r
             .scan()
@@ -488,6 +492,10 @@ mod tests {
         assert!(results.iter().any(|p| p.name == "neovim"));
         assert!(results.iter().any(|p| p.name == "emacs"));
         assert!(results.iter().any(|p| p.name == "avim"));
+
+        // Empty search terms keep the previous public API behavior: no matches.
+        let results = db.search_packages(&[], 10)?;
+        assert!(results.is_empty());
 
         Ok(())
     }


### PR DESCRIPTION
This PR improves the package search functionality by changing the multi-term search logic from an OR condition (`.any`) to an AND condition (`.all`). This is highly valuable because it significantly increases search precision; users querying for multiple terms (e.g., "text editor") expect packages that match *all* terms, rather than an overwhelming list of packages matching *any* of the terms. A test was also added to ensure correct multi-term filtering.

---
*PR created automatically by Jules for task [17144452859674178328](https://jules.google.com/task/17144452859674178328) started by @insign*