### PR TITLE
Fix error suppression during native_db scans

### DIFF
--- a/crates/xpm-core/src/db/operations.rs
+++ b/crates/xpm-core/src/db/operations.rs
@@ -80,7 +80,11 @@ impl Database {
     /// Get all packages
     pub fn get_all_packages(&self) -> Result<Vec<Package>> {
         let r = self.db.r_transaction()?;
-        let packages: Vec<Package> = r.scan().primary()?.all()?.filter_map(|p| p.ok()).collect();
+        let packages: Vec<Package> = r
+            .scan()
+            .primary()?
+            .all()?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(packages)
     }
 
@@ -91,9 +95,8 @@ impl Database {
             .scan()
             .primary()?
             .all()?
-            .filter_map(|p| p.ok())
             .take(limit)
-            .collect();
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(packages)
     }
 
@@ -117,7 +120,8 @@ impl Database {
             .scan()
             .primary()?
             .all()?
-            .filter_map(|p| p.ok())
+            .collect::<std::result::Result<Vec<_>, _>>()?
+            .into_iter()
             .filter(|pkg: &Package| {
                 terms_lower.iter().all(|term| {
                     pkg.name.to_lowercase().contains(term)
@@ -151,7 +155,8 @@ impl Database {
             .scan()
             .primary()?
             .all()?
-            .filter_map(|p| p.ok())
+            .collect::<std::result::Result<Vec<_>, _>>()?
+            .into_iter()
             .filter(|pkg: &Package| pkg.is_installed())
             .collect();
 
@@ -189,7 +194,8 @@ impl Database {
             .scan()
             .primary()?
             .all()?
-            .filter_map(|p| p.ok())
+            .collect::<std::result::Result<Vec<_>, _>>()?
+            .into_iter()
             .filter(|pkg: &Package| !pkg.is_installed())
             .collect();
 
@@ -208,7 +214,11 @@ impl Database {
     /// Get all repositories
     pub fn get_all_repos(&self) -> Result<Vec<Repo>> {
         let r = self.db.r_transaction()?;
-        let repos: Vec<Repo> = r.scan().primary()?.all()?.filter_map(|p| p.ok()).collect();
+        let repos: Vec<Repo> = r
+            .scan()
+            .primary()?
+            .all()?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(repos)
     }
 
@@ -371,7 +381,8 @@ impl Database {
             .scan()
             .primary()?
             .all()?
-            .filter_map(|p| p.ok())
+            .collect::<std::result::Result<Vec<_>, _>>()?
+            .into_iter()
             .filter(|s: &Setting| s.is_expired())
             .collect();
 


### PR DESCRIPTION
Melhoria escolhida: Correção de erro silencioso em operações do banco de dados (Confiabilidade / Correção de bug)

Por que agrega valor real ao projeto: A utilização de `.filter_map(|p| p.ok())` ignorava silenciosamente erros de desserialização ou corrupção no banco de dados local. Isso faria com que os pacotes simplesmente desaparecessem sem aviso caso houvesse algum problema, escondendo falhas críticas no `native_db`. Ao alterar para coletar um `Result` e utilizar `?` (como `.collect::<std::result::Result<Vec<_>, _>>()?`), os erros são propagados corretamente, impedindo a perda silenciosa de dados e avisando o usuário sobre possíveis falhas.

Arquivos alterados:
- `crates/xpm-core/src/db/operations.rs`: Substituído todas as ocorrências de `.filter_map(|p| p.ok())` por coleções corretas de resultados.

Atualização em .md: Nenhuma, pois a mudança é de comportamento interno no tratamento de erros do banco e a documentação não foi invalidada.

Impacto nos testes: Todos os testes foram mantidos e executados via `cargo test`, continuando a passar sem alterações.

Observações: Nenhuma dependência foi adicionada ou modificada e todas as restrições sobre evitar arquivos temporários foram atendidas (arquivos auxiliares foram removidos e o log de git status comprova limpeza).

---
*PR created automatically by Jules for task [13857551096621645205](https://jules.google.com/task/13857551096621645205) started by @insign*